### PR TITLE
feat: move to tock_registers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ byteorder = { version = "1.4", default-features = false }
 embedded-hal = { version = "0.2", optional = true }
 enum_primitive = { git = "https://github.com/mirage-rs/enum_primitive-rs.git" }
 paste = "1.0.4"
-register = "1.0.2"
 static_assertions = "1.1"
+tock-registers = "0.7.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 cortex-a = "7.2"

--- a/src/actmon/registers.rs
+++ b/src/actmon/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::ACTMON;
 

--- a/src/ahb/registers.rs
+++ b/src/ahb/registers.rs
@@ -3,7 +3,7 @@
 /// See Chapter 19.4.2 in the Tegra X1 Technical Reference
 /// Manual for details.
 pub mod mem {
-    use register::{mmio::*, register_structs};
+    use tock_registers::{register_structs, registers::*};
 
     use crate::memory_map::SYSREG;
 

--- a/src/apb/dma/channel.rs
+++ b/src/apb/dma/channel.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::apb_dma::*;
 

--- a/src/apb/dma/core.rs
+++ b/src/apb/dma/core.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::apb_dma;
 

--- a/src/apb/dma/mod.rs
+++ b/src/apb/dma/mod.rs
@@ -8,6 +8,8 @@ pub use channel::*;
 mod channel;
 mod core;
 
+use tock_registers::interfaces::*;
+
 /// Representation of the AMBA Peripheral Bus DMA Controller.
 ///
 /// The controller manages 32 DMA [`Channel`]s, which are used to transfer data over DMA.

--- a/src/apb/misc.rs
+++ b/src/apb/misc.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous system control registers.
 
-use register::{mmio::ReadWrite, register_structs};
+use tock_registers::{register_structs, registers::ReadWrite};
 
 use crate::memory_map::APB;
 
@@ -8,7 +8,7 @@ use crate::memory_map::APB;
 pub const REGISTERS: *const AmbaPeripheralBus = APB as *const AmbaPeripheralBus;
 
 pub mod misc_pp {
-    use register::{mmio::*, register_bitfields, register_structs};
+    use tock_registers::{register_bitfields, register_structs, registers::*};
 
     register_bitfields! {
         u32,
@@ -68,7 +68,7 @@ pub mod misc_pp {
 }
 
 pub mod misc_gp {
-    use register::{mmio::*, register_structs};
+    use tock_registers::{register_structs, registers::*};
 
     // TODO: Bitfields.
 

--- a/src/arm/gic.rs
+++ b/src/arm/gic.rs
@@ -3,6 +3,8 @@
 use core::fmt;
 use core::marker::PhantomData;
 
+use tock_registers::interfaces::*;
+
 /// An interrupt request for the GIC.
 pub type Irq = IrqNumber<{ Gic::NUM_IRQS }>;
 
@@ -165,7 +167,7 @@ impl Gic {
         // Find the index of the `ICFGR[i]` register corresponding to the IRQ
         // number and determine the trigger configuration value to write.
         let icfgr_reg_index = irq_num >> 4;
-        let icfgr_value = ((mode as u32) << 1) << (irq_num % 16) * 2;
+        let icfgr_value = ((mode as u32) << 1) << ((irq_num % 16) * 2);
 
         // Set the bits in the corresponding ICFGR register.
         let icfgr = &gicd.GICD_ICFGR[icfgr_reg_index];
@@ -333,7 +335,7 @@ impl<const MAX: usize> fmt::Display for IrqNumber<{ MAX }> {
 /// of the GICC when accessing the same registers. It is used to acknowledge and handle
 /// pending IRQs.
 pub mod gicc {
-    use register::{mmio::*, register_bitfields, register_structs};
+    use tock_registers::{register_bitfields, register_structs, registers::*};
 
     register_bitfields! {
         u32,
@@ -453,7 +455,7 @@ pub mod gicc {
 /// Unlike for the GICC, access to these registers is only banked for a few registers
 /// and other than that, all CPU cores see the same instance of the Distributor.
 pub mod gicd {
-    use register::{mmio::*, register_bitfields, register_structs};
+    use tock_registers::{register_bitfields, register_structs, registers::*};
 
     // TODO: Add missing bitfields.
 

--- a/src/atomic/mod.rs
+++ b/src/atomic/mod.rs
@@ -4,6 +4,8 @@
 
 #![allow(unused)]
 
+use tock_registers::interfaces::*;
+
 mod registers;
 pub use registers::*;
 
@@ -244,8 +246,8 @@ impl AtomicU64 {
 
         // if the comparison succeeded, the previous value will be in the result register,
         // but we don't return it because it may be undefined
-        register!(RESULT_0)[self.target_register as usize].get() as u64;
-        register!(RESULT_0)[self.target_register as usize + 1].get() as u64;
+        register!(RESULT_0)[self.target_register as usize].get();
+        register!(RESULT_0)[self.target_register as usize + 1].get();
     }
 
     /// Increment the value of this atomic by `x`.

--- a/src/atomic/registers.rs
+++ b/src/atomic/registers.rs
@@ -12,7 +12,7 @@
 //! - Result Phase: The results of the operation are made available in the result register.
 
 use crate::memory_map::ATOMICS;
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 /// A pointer to the Atomic register block.
 pub const REGISTERS: *const Registers = ATOMICS as *const Registers;

--- a/src/bpmp.rs
+++ b/src/bpmp.rs
@@ -45,6 +45,7 @@
 //!
 //! ```no_run
 //! use libtegra::{bpmp, pmc};
+//! use tock_registers::interfaces::*;
 //!
 //! /// Forcefully reboots the SoC into Recovery Mode.
 //! unsafe fn reboot_to_rcm() -> ! {
@@ -76,6 +77,8 @@
 
 use core::cmp::min;
 
+use tock_registers::interfaces::*;
+
 use crate::flow;
 
 /// Sleeps for the given amount of microseconds.
@@ -95,7 +98,9 @@ pub fn usleep(mut microseconds: u32) {
         microseconds -= delay;
 
         // Halt the CPU for the given duration.
-        controller.FLOW_CTLR_HALT_COP_EVENTS_0.set(0x4200_0000 | delay);
+        controller
+            .FLOW_CTLR_HALT_COP_EVENTS_0
+            .set(0x4200_0000 | delay);
     }
 }
 
@@ -116,7 +121,9 @@ pub fn msleep(mut milliseconds: u32) {
         milliseconds -= delay;
 
         // Halt the CPU for the given duration.
-        controller.FLOW_CTLR_HALT_COP_EVENTS_0.set(0x4100_0000 | delay);
+        controller
+            .FLOW_CTLR_HALT_COP_EVENTS_0
+            .set(0x4100_0000 | delay);
     }
 }
 
@@ -126,6 +133,6 @@ pub fn halt() {
 
     controller.FLOW_CTLR_HALT_COP_EVENTS_0.modify(
         flow::FLOW_CTLR_HALT_COP_EVENTS_0::MODE::FlowModeWaitevent
-        + flow::FLOW_CTLR_HALT_COP_EVENTS_0::JTAG::SET
+            + flow::FLOW_CTLR_HALT_COP_EVENTS_0::JTAG::SET,
     );
 }

--- a/src/car/clock.rs
+++ b/src/car/clock.rs
@@ -1,4 +1,4 @@
-use register::mmio::ReadWrite;
+use tock_registers::{interfaces::*, registers::ReadWrite};
 
 use crate::{memory_map::CAR, timer::usleep};
 

--- a/src/car/registers.rs
+++ b/src/car/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_structs};
+use tock_registers::{register_structs, registers::*};
 
 use crate::memory_map::CAR;
 

--- a/src/dsi/registers.rs
+++ b/src/dsi/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::{DSIA, DSIB};
 

--- a/src/flow/mod.rs
+++ b/src/flow/mod.rs
@@ -8,7 +8,7 @@
 //! The Flow Controller provides the sequencing of hardware-controlled
 //! CPU power states for the main CPU complex and the BPMP.
 
-use register::mmio::ReadWrite;
+use tock_registers::{interfaces::*, registers::ReadWrite};
 
 use crate::car;
 use crate::memory_map::EXCEPTION_VECTORS;

--- a/src/flow/registers.rs
+++ b/src/flow/registers.rs
@@ -3,7 +3,7 @@
 //! See Chapter 17.2 in the Tegra X1 Technical Reference Manual for
 //! details.
 
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::FLOW;
 

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -4,6 +4,8 @@ use crate::{car, pmc, timer::msleep};
 
 pub use registers::*;
 
+use tock_registers::interfaces::*;
+
 mod registers;
 
 /// Initializes the FUSE driver.

--- a/src/fuse/registers.rs
+++ b/src/fuse/registers.rs
@@ -1,6 +1,6 @@
 use core::mem::ManuallyDrop;
 
-use register::{mmio::ReadWrite, register_structs};
+use tock_registers::{register_structs, registers::ReadWrite};
 
 use crate::memory_map::FUSE;
 
@@ -76,7 +76,7 @@ register_structs! {
 assert_eq_size!(Registers, [u8; 0x98]);
 
 pub mod chip_common {
-    use register::{mmio::ReadWrite, register_structs};
+    use tock_registers::{register_structs, registers::ReadWrite};
 
     register_structs! {
         /// Representation of the FUSE chip registers shared between Erista and Mariko.
@@ -205,7 +205,7 @@ pub mod chip_common {
 }
 
 pub mod chip_erista {
-    use register::{mmio::ReadWrite, register_structs};
+    use tock_registers::{register_structs, registers::ReadWrite};
 
     register_structs! {
         /// Representation of the FUSE chip registers for Erista.
@@ -347,7 +347,7 @@ pub mod chip_erista {
 
 #[cfg(feature = "mariko")]
 pub mod chip_mariko {
-    use register::{mmio::ReadWrite, register_structs};
+    use tock_registers::{register_structs, registers::ReadWrite};
 
     /// Additional fuse chip registers which are only available on Mariko.
     #[allow(non_snake_case)]

--- a/src/gpio/controller.rs
+++ b/src/gpio/controller.rs
@@ -1,4 +1,4 @@
-use register::{mmio::ReadWrite, register_structs};
+use tock_registers::{register_structs, registers::ReadWrite};
 
 use crate::memory_map::gpio::BASE;
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -45,10 +45,12 @@ mod hal;
 
 pub use crate::gpio::controller::*;
 
+use tock_registers::interfaces::*;
+
 use enum_primitive::FromPrimitive;
 #[doc(hidden)]
 pub use paste::paste;
-use register::mmio::ReadWrite;
+use tock_registers::registers::ReadWrite;
 
 /// The GPIO ports that are supported by the platform.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/hal/delay.rs
+++ b/src/hal/delay.rs
@@ -2,6 +2,7 @@ use embedded_hal::blocking::delay;
 
 use crate::timer;
 
+#[derive(Default)]
 pub struct Delay;
 
 impl Delay {

--- a/src/i2c/controller.rs
+++ b/src/i2c/controller.rs
@@ -3,6 +3,8 @@ use core::convert::TryInto;
 use crate::i2c::registers::*;
 use crate::{car::Clock, timer};
 
+use tock_registers::interfaces::*;
+
 fn bytes_to_word(buf: &[u8]) -> u32 {
     if buf.len() == 4 {
         u32::from_le_bytes(buf.try_into().unwrap())
@@ -143,7 +145,7 @@ impl I2c {
 
         // Set device for 7-bit write mode.
         i2c.I2C_I2C_CMD_ADDR0_0
-            .write(I2C_I2C_CMD_ADDR0_0::ADDR0.val((device << 1) | 0));
+            .write(I2C_I2C_CMD_ADDR0_0::ADDR0.val(device << 1));
 
         // Load in data to transmit.
         let (data1_value, data2_value) = bytes_to_double_word(buffer);

--- a/src/i2c/registers.rs
+++ b/src/i2c/registers.rs
@@ -1,4 +1,6 @@
-use register::{mmio::*, register_bitfields, register_structs};
+#![allow(clippy::zero_prefixed_literal)]
+
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::i2c::*;
 

--- a/src/kfuse/mod.rs
+++ b/src/kfuse/mod.rs
@@ -33,6 +33,8 @@ mod registers;
 use crate::car::Clock;
 pub use crate::kfuse::registers::*;
 
+use tock_registers::interfaces::*;
+
 /// The size of the buffer in words required for reading all encrypted HDMI keys from
 /// the KFUSE.
 pub const KFUSE_KEY_BUFFER_SIZE: usize = 576 >> 2;

--- a/src/kfuse/registers.rs
+++ b/src/kfuse/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::KFUSE;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![recursion_limit = "1024"]
+#![allow(clippy::result_unit_err)]
 
 #[macro_use]
 extern crate enum_primitive;

--- a/src/mc/mod.rs
+++ b/src/mc/mod.rs
@@ -9,6 +9,8 @@ pub use registers::*;
 
 mod registers;
 
+use tock_registers::interfaces::*;
+
 /// Configures the Memory Controller TSEC carveout.
 pub fn config_tsec_carveout(bom: u32, size_mb: u32, lock: bool) {
     let controller = unsafe { &*REGISTERS };
@@ -124,9 +126,8 @@ pub fn enable_ahb_redirect() {
     let controller = unsafe { &*REGISTERS };
     let car = unsafe { &*car::REGISTERS };
 
-    car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.set(
-        (car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.get() & 0xFFF7_FFFF) | 0x80000
-    );
+    car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0
+        .set((car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.get() & 0xFFF7_FFFF) | 0x80000);
 
     controller.MC_IRAM_BOM_0.set(0x4000_0000);
     controller.MC_IRAM_TOM_0.set(0x4003_F000);
@@ -140,9 +141,8 @@ pub fn disable_ahb_redirect() {
     controller.MC_IRAM_BOM_0.set(0xFFFF_F000);
     controller.MC_IRAM_TOM_0.set(0);
 
-    car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.set(
-        car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.get() & 0xFFF7_FFFF
-    );
+    car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0
+        .set(car.CLK_RST_CONTROLLER_LVL2_CLK_GATE_OVRD_0.get() & 0xFFF7_FFFF);
 }
 
 /// Enables the Memory Controller.
@@ -150,24 +150,20 @@ pub fn enable_mc() {
     let car = unsafe { &*car::REGISTERS };
 
     // Set EMC clock source.
-    car.CLK_RST_CONTROLLER_CLK_SOURCE_EMC_0.set(
-        (car.CLK_RST_CONTROLLER_CLK_SOURCE_EMC_0.get() & 0x1FFF_FFFF) | 0x4000_0000
-    );
+    car.CLK_RST_CONTROLLER_CLK_SOURCE_EMC_0
+        .set((car.CLK_RST_CONTROLLER_CLK_SOURCE_EMC_0.get() & 0x1FFF_FFFF) | 0x4000_0000);
 
     // Enable MIPI CAL clock.
-    car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.set(
-        (car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.get() & 0xFDFF_FFFF) | 0x2000000
-    );
+    car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0
+        .set((car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.get() & 0xFDFF_FFFF) | 0x2000000);
 
     // Enable MC clock.
-    car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.set(
-        (car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.get() & 0xFFFF_FFFE) | 1
-    );
+    car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0
+        .set((car.CLK_RST_CONTROLLER_CLK_ENB_H_SET_0.get() & 0xFFFF_FFFE) | 1);
 
     // Enable EMC DLL clock.
-    car.CLK_RST_CONTROLLER_CLK_ENB_X_SET_0.set(
-        (car.CLK_RST_CONTROLLER_CLK_ENB_X_SET_0.get() & 0xFFFF_BFFF) | 0x4000
-    );
+    car.CLK_RST_CONTROLLER_CLK_ENB_X_SET_0
+        .set((car.CLK_RST_CONTROLLER_CLK_ENB_X_SET_0.get() & 0xFFFF_BFFF) | 0x4000);
 
     // Clear EMC and MC reset.
     car.CLK_RST_CONTROLLER_RST_DEV_H_CLR_0.set(0x2000001);

--- a/src/mc/registers.rs
+++ b/src/mc/registers.rs
@@ -3,7 +3,7 @@
 //! See Chapter 18.11 in the Tegra X1 Technical Reference Manual
 //! for details.
 
-use register::{mmio::*, register_structs};
+use tock_registers::{register_structs, registers::*};
 
 use crate::memory_map::MC;
 

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::identity_op)]
 //! Unified Tegra X1 Memory Address Map constants.
 //!
 //! See Chapter 2 in the Tegra X1 Technical Reference Manual for details.

--- a/src/pinmux/mod.rs
+++ b/src/pinmux/mod.rs
@@ -36,7 +36,7 @@
 mod registers;
 
 use enum_primitive::FromPrimitive;
-use register::mmio::ReadWrite;
+use tock_registers::{interfaces::*, registers::*};
 
 pub use crate::pinmux::registers::*;
 
@@ -44,7 +44,7 @@ pub use crate::pinmux::registers::*;
 ///
 /// Many drivers of the `libtegra` crate depend on proper Pin Multiplexing settings
 /// for the specific board before they can be used.
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum PinGrP {
     Sdmmc1ClkPm0,
     Sdmmc1CmdPm1,
@@ -219,7 +219,7 @@ enum_from_primitive! {
     /// Note that most pins are actually predestined for a specific pin functions among
     /// reserved ones. The driver will make sure that no unsupported pin function can be
     /// set on the wrong pin.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     pub enum PinFunction {
         Default,
         Aud,
@@ -305,7 +305,7 @@ enum_from_primitive! {
     /// State control for the Pull bit as a part of Pin configuration.
     ///
     /// The Pull Resistor bit can be configured to Pull-up, Pull-down or nothing per pad.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinPull {
         /// Nothing.
@@ -324,7 +324,7 @@ enum_from_primitive! {
     ///
     /// Enables or disables the pad's output driver and thus overrides whether the pad is
     /// used as an SFIO or GPIO. For normal operations, a pad should be set to Passthrough.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinTristate {
         /// Disables the pad's Tristate.
@@ -341,7 +341,7 @@ enum_from_primitive! {
     /// be put into PARKING state. Until pinmux recovery code on LP0 exit clears this bit,
     /// the pin will remain in LP0 state in the same value as that of LP0 entry. A Default
     /// state is provided to preserve the setting of this bit without touching it.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinPark {
         /// Normal state.
@@ -358,7 +358,7 @@ enum_from_primitive! {
     ///
     /// Depending on whether or not the Input Receiver of a pad is enabled through this setting,
     /// the pad will have either input or output direction for I/O.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinIo {
         /// Output direction configuration.
@@ -374,7 +374,7 @@ enum_from_primitive! {
     /// The Lock bit, as the name may suggest, locks down or grants write access
     /// to the pad that is configured with it, respectively. A Default state is
     /// provided to preserve the setting of the bit without touching it.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinLock {
         /// No lock control.
@@ -392,7 +392,7 @@ enum_from_primitive! {
     /// When interfacing chips require minimal rise and fall times, this can be set to
     /// enable Base Drivers to fine-tune their behavior. A Default state is provided
     /// to preserve the setting of this bit without touching it.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinLpdr {
         /// Disables LPDR.
@@ -410,7 +410,7 @@ enum_from_primitive! {
     /// This is marked as reserved by the Tegra Reference Manual and should never be set
     /// to another value than its default. For that reason, a Default state is provided
     /// to enforce this rule and skip direct modification of the bit's value.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinOd {
         /// Disables OD.
@@ -430,7 +430,7 @@ enum_from_primitive! {
     /// If pins are in need of 3.3V operation, open-drain pull-up capability can be enabled
     /// on them using this setting. A Default state is provided to preserve the setting of
     /// this bit without touching it.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinIoHv {
         /// Enables regular-voltage operation.
@@ -447,7 +447,7 @@ enum_from_primitive! {
     ///
     /// Enables or disables the Schmitt trigger on a given pad. A Default state is provided
     /// to preserve the setting of this bit without touching it.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinSchmt {
         /// Disables Schmitt mode on a pin.
@@ -465,7 +465,7 @@ enum_from_primitive! {
     /// Enables different combinations of impedance code mapping on a given pad. This
     /// can be configured for every supported pad individually and allows for fine-tuning
     /// the impedance of an individual pad.
-    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
     #[repr(u32)]
     pub enum PinDrive {
         /// 1X drive.
@@ -2018,8 +2018,8 @@ impl PinGrP {
 
         // Set the bits accordingly.
         let mut value = register.get();
-        value &= !(3 << 0);
-        value |= mux << 0;
+        value &= !3;
+        value |= mux;
         register.set(value);
     }
 

--- a/src/pinmux/registers.rs
+++ b/src/pinmux/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::ReadWrite, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::MISC;
 

--- a/src/pmc/mod.rs
+++ b/src/pmc/mod.rs
@@ -50,6 +50,7 @@
 //! [`powergate_partition`]: fn.powergate_partition.html
 
 use crate::timer::usleep;
+use tock_registers::interfaces::*;
 
 pub use registers::*;
 

--- a/src/pmc/registers.rs
+++ b/src/pmc/registers.rs
@@ -1,4 +1,4 @@
-use register::mmio::*;
+use tock_registers::registers::*;
 
 use crate::memory_map::PMC;
 
@@ -609,7 +609,7 @@ pub struct Registers {
 assert_eq_size!(Registers, [u8; 0xB38]);
 
 pub mod counter0 {
-    use register::{mmio::*, register_bitfields, register_structs};
+    use tock_registers::{register_bitfields, register_structs, registers::*};
 
     use crate::memory_map::SYSCTR0;
 
@@ -694,7 +694,7 @@ pub mod counter0 {
 }
 
 pub mod sb {
-    use register::{mmio::ReadWrite, register_structs};
+    use tock_registers::{register_structs, registers::ReadWrite};
 
     use crate::memory_map::SB;
 

--- a/src/pwm/mod.rs
+++ b/src/pwm/mod.rs
@@ -14,6 +14,7 @@ mod registers;
 mod hal;
 
 pub use crate::pwm::registers::*;
+use tock_registers::interfaces::*;
 
 /// Representation of a Pulse Width Modulator channel.
 ///
@@ -76,7 +77,7 @@ impl PwmChannel {
     pub fn set_pulse_width(&self, duty: f32) -> Result<(), ()> {
         let controller = unsafe { &*self.registers };
 
-        if duty < 0.0 || duty > 1.0 {
+        if !(0.0..=1.0).contains(&duty) {
             return Err(());
         }
 

--- a/src/pwm/registers.rs
+++ b/src/pwm/registers.rs
@@ -1,7 +1,7 @@
-use register::{mmio::ReadWrite, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::PWM;
-
+#[allow(clippy::identity_op)]
 /// A pointer to the PWM_0 register block that can be accessed by dereferencing it.
 pub const PWM_0_REGISTERS: *const Registers = (PWM + 0x00) as *const Registers;
 /// A pointer to the PWM_1 register block that can be accessed by dereferencing it.

--- a/src/se/aes.rs
+++ b/src/se/aes.rs
@@ -1,5 +1,5 @@
 use byteorder::{ByteOrder, LE};
-use register::FieldValue;
+use tock_registers::{fields::FieldValue, interfaces::*};
 
 use crate::arm;
 use crate::se::constants::*;
@@ -152,7 +152,7 @@ pub fn clear_key_iv(registers: &Registers, slot: u32) {
 }
 
 fn set_iv(registers: &Registers, slot: u32, iv: &[u8]) {
-    assert_eq!(iv.len() % aes::BLOCK_SIZE >> 2, 0);
+    assert_eq!((iv.len() % aes::BLOCK_SIZE) >> 2, 0);
 
     for (i, c) in iv.chunks(aes::BLOCK_SIZE >> 2).enumerate() {
         // Select the next original IV word in the keyslot.
@@ -226,7 +226,7 @@ pub fn set_encrypted_key(
     }
 
     // Prepare the linked lists and kick off the operation.
-    let source_ll = LinkedList::from(&key[..]);
+    let source_ll = LinkedList::from(key);
     let mut destination_ll = LinkedList::default();
     start_normal_operation(registers, &source_ll, &mut destination_ll)
 }
@@ -371,7 +371,7 @@ pub fn do_cbc_operation(
 
     // Prepare the linked lists and kick off the operation.
     let source_ll = LinkedList::from(&source[..aligned_size]);
-    let mut destination_ll = LinkedList::from(&destination[..]);
+    let mut destination_ll = LinkedList::from(destination as &[u8]);
     start_normal_operation(registers, &source_ll, &mut destination_ll)
 }
 

--- a/src/se/core.rs
+++ b/src/se/core.rs
@@ -1,6 +1,6 @@
-use core::convert::TryFrom;
 #[allow(unused)]
 use core::arch::asm;
+use core::convert::TryFrom;
 use core::mem::size_of;
 
 use crate::ahb::mem;
@@ -8,6 +8,8 @@ use crate::arm;
 use crate::se::constants::*;
 use crate::se::registers::*;
 use crate::timer;
+
+use tock_registers::interfaces::*;
 
 /// Address information of a DMA buffer.
 ///

--- a/src/se/hash.rs
+++ b/src/se/hash.rs
@@ -2,6 +2,8 @@ use byteorder::{ByteOrder, BE, LE};
 
 use crate::se::registers::*;
 
+use tock_registers::interfaces::*;
+
 macro_rules! init_sha {
     ($registers:ident, $mode:ident) => {
         // Configure the hardware to perform a SHA hashing operation.

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -162,6 +162,8 @@ mod utils;
 
 use ::core::marker::Sync;
 
+use tock_registers::interfaces::*;
+
 pub use self::core::*;
 use crate::arm;
 pub use aes::Mode as AesMode;
@@ -293,7 +295,7 @@ impl SecurityEngine {
     /// This must be done prior to any encryptions using this slot.
     pub fn fill_aes_keyslot(&self, slot: u32, key: &[u8]) {
         assert!(slot < constants::aes::KEY_SLOT_COUNT as u32);
-        assert_eq!(key.len() % constants::aes::BLOCK_SIZE >> 2, 0);
+        assert_eq!((key.len() % constants::aes::BLOCK_SIZE) >> 2, 0);
         assert!(key.len() <= constants::aes::MAX_KEY_SIZE);
 
         let engine = unsafe { &*self.registers };
@@ -303,7 +305,7 @@ impl SecurityEngine {
     /// Copies a previously loaded AES key out of a given keyslot.
     pub fn get_aes_key(&self, slot: u32, key: &mut [u8]) {
         assert!(slot < constants::aes::KEY_SLOT_COUNT as u32);
-        assert_eq!(key.len() % constants::aes::BLOCK_SIZE >> 2, 0);
+        assert_eq!((key.len() % constants::aes::BLOCK_SIZE) >> 2, 0);
         assert!(key.len() <= constants::aes::MAX_KEY_SIZE);
 
         let engine = unsafe { &*self.registers };
@@ -342,7 +344,7 @@ impl SecurityEngine {
     ) -> Result<(), OperationError> {
         assert!(dest_slot < constants::aes::KEY_SLOT_COUNT as u32);
         assert!(kek_slot < constants::aes::KEY_SLOT_COUNT as u32);
-        assert_eq!(key.len() % constants::aes::BLOCK_SIZE >> 2, 0);
+        assert_eq!((key.len() % constants::aes::BLOCK_SIZE) >> 2, 0);
         assert!(key.len() <= constants::aes::MAX_KEY_SIZE);
 
         let engine = unsafe { &*self.registers };

--- a/src/se/registers.rs
+++ b/src/se/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::SE1;
 #[cfg(feature = "mariko")]

--- a/src/se/rng.rs
+++ b/src/se/rng.rs
@@ -3,6 +3,8 @@ use crate::se::core::*;
 use crate::se::registers::*;
 use crate::se::utils::trigger_single_block_operation;
 
+use tock_registers::interfaces::*;
+
 macro_rules! init_rng {
     ($registers:ident, $dest:ident, $mode:ident) => {
         // Configure the hardware to do RNG encryption.

--- a/src/se/rsa.rs
+++ b/src/se/rsa.rs
@@ -1,5 +1,5 @@
 use byteorder::{ByteOrder, BE};
-use register::FieldValue;
+use tock_registers::{fields::FieldValue, interfaces::*};
 
 use crate::se::constants::*;
 use crate::se::core::*;

--- a/src/se/utils.rs
+++ b/src/se/utils.rs
@@ -3,6 +3,8 @@ use crate::se::constants::*;
 use crate::se::core::*;
 use crate::se::registers::*;
 
+use tock_registers::interfaces::*;
+
 pub fn trigger_single_block_operation(
     engine: &Registers,
     source: &[u8],

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -10,6 +10,8 @@ use core::{convert::TryInto, marker::Sync};
 pub use crate::spi::registers::*;
 use crate::timer::usleep;
 
+use tock_registers::interfaces::*;
+
 /// Representation of an SPI.
 ///
 /// NOTE: Instances of this structure should never be created manually.

--- a/src/spi/registers.rs
+++ b/src/spi/registers.rs
@@ -1,4 +1,5 @@
-use register::{mmio::*, register_bitfields, register_structs};
+#![allow(clippy::zero_prefixed_literal)]
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::{spi::*, QSPI};
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -11,6 +11,8 @@ use crate::apb;
 const JEDEC_NVIDIA_MFID: u32 = 0x6B;
 const JEDEC_NVIDIA_BKID: u32 = 0x03;
 
+use tock_registers::interfaces::*;
+
 unsafe fn get_chip_id() -> (u32, u32, u32, u32, u32) {
     let hidrev = (*apb::misc::REGISTERS).gp.APB_MISC_GP_HIDREV_0.get();
 

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -37,6 +37,8 @@
 pub mod rtc;
 pub mod timerus;
 
+use tock_registers::interfaces::*;
+
 /// Reads the current time in seconds.
 #[inline]
 pub fn get_seconds() -> u32 {

--- a/src/timer/rtc.rs
+++ b/src/timer/rtc.rs
@@ -11,7 +11,7 @@
 //! triggered by the RTC can cause the system to wake up from a low-power
 //! state.
 
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::RTC;
 

--- a/src/timer/timerus.rs
+++ b/src/timer/timerus.rs
@@ -8,7 +8,7 @@
 //! to be used by the rest of the system regardless of the clk_m frequency
 //! (i.e., 12 MHz or 38.4 MHz).
 
-use register::{mmio::ReadWrite, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::TMR;
 

--- a/src/tsec/mod.rs
+++ b/src/tsec/mod.rs
@@ -102,6 +102,7 @@ mod registers;
 use core::ops::{Deref, DerefMut};
 
 use enum_primitive::FromPrimitive;
+use tock_registers::interfaces::*;
 
 use crate::car::Clock;
 use crate::kfuse;

--- a/src/tsec/registers.rs
+++ b/src/tsec/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::{TSEC, TSEC2};
 
@@ -131,7 +131,7 @@ register_bitfields! {
             HdcpEncryptPairingInfo = 0x518,
             HdcpDecryptPairingInfo = 0x51C,
             HdcpUpdateSession = 0x520,
-            HdcpGenerateLcInit = 0524,
+            HdcpGenerateLcInit = 0x524,
             HdcpVerifyLprime = 0x528,
             HdcpGenerateSkeInit = 0x52C,
             HdcpVerifyVprime = 0x530,

--- a/src/uart/mod.rs
+++ b/src/uart/mod.rs
@@ -78,6 +78,8 @@ use core::{
     marker::Sync,
 };
 
+use tock_registers::interfaces::*;
+
 pub use crate::uart::registers::*;
 use crate::{car::Clock, timer::usleep};
 

--- a/src/uart/registers.rs
+++ b/src/uart/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::uart::*;
 

--- a/src/vic/registers.rs
+++ b/src/vic/registers.rs
@@ -1,4 +1,4 @@
-use register::{mmio::*, register_bitfields, register_structs};
+use tock_registers::{register_bitfields, register_structs, registers::*};
 
 use crate::memory_map::VIC;
 


### PR DESCRIPTION
This merge request moves the crate away from the deprecated `register` crate and to the new `tock_registers` crate.

It also fixes the value for `HdcpGenerateLcInit` in TSEC.

🐈‍⬛ 🖤 